### PR TITLE
Update QuestPDF to 2202.8.2.

### DIFF
--- a/PdfGenerator.Core/PdfGenerator.Core.csproj
+++ b/PdfGenerator.Core/PdfGenerator.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="QuestPDF" Version="2022.5.0" />
+    <PackageReference Include="QuestPDF" Version="2202.8.2" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
QuestPDF embedds the default font `Lato` now.