### PR TITLE
Fix test warnings.

### DIFF
--- a/PdfGenerator.Test/Services/FilenameService.cs
+++ b/PdfGenerator.Test/Services/FilenameService.cs
@@ -1,21 +1,16 @@
 using PdfGenerator.Services;
 
 namespace PdfGenerator.Test.Services;
-public class FilenameServiceTests
-{
-  private FileNameService? sut;
 
-  [SetUp]
-  public void Setup()
-  {
-    sut = new FileNameService();
-  }
+public class FilenameServiceTests : TestBase<FileNameService>
+{
+  protected override FileNameService DoSetup() => new();
 
   [Test]
   public void TestReplace_InputIsStringWithoutPlaceholders_ReturnResultEqualToStringWithoutPlaceholders()
   {
     var stringWithoutPlaceholders = "testname_without_placeholders.pdf";
-    var result = sut.Replace(stringWithoutPlaceholders, 500, 500, 10);
+    var result = Sut.Replace(stringWithoutPlaceholders, 500, 500, 10);
 
     Assert.That(result, Is.EqualTo(stringWithoutPlaceholders));
   }
@@ -24,7 +19,7 @@ public class FilenameServiceTests
   public void TestReplace_InputIsIntegerRanger_ReturnFilenameWithPlaceholdersReplaced([Range(1, 10)] int pageCount, [Range(550, 555)] int width, [Range(600, 605)] int height)
   {
     var stringPlaceholders = "test_{{PAGE_WIDTH}}_{{PAGE_HEIGHT}}_{{PAGE_COUNT}}.pdf";
-    var result = sut.Replace(stringPlaceholders, width, height, pageCount);
+    var result = Sut.Replace(stringPlaceholders, width, height, pageCount);
 
     Assert.That(result, Is.EqualTo($"test_{width}_{height}_{pageCount}.pdf"));
   }
@@ -33,7 +28,7 @@ public class FilenameServiceTests
   public void TestReplace_InputIsIntegerRanger_ReturnFilenameWithMultiplePlaceholdersReplaced([Range(1, 10)] int pageCount, [Range(550, 555)] int width, [Range(600, 605)] int height)
   {
     var stringPlaceholders = "test_{{PAGE_WIDTH}}_{{PAGE_HEIGHT}}_{{PAGE_COUNT}}_{{PAGE_COUNT}}.pdf";
-    var result = sut.Replace(stringPlaceholders, width, height, pageCount);
+    var result = Sut.Replace(stringPlaceholders, width, height, pageCount);
 
     Assert.That(result, Is.EqualTo($"test_{width}_{height}_{pageCount}_{pageCount}.pdf"));
   }
@@ -43,7 +38,7 @@ public class FilenameServiceTests
   {
     var stringPlaceholders = "test_{{PAGE_WIDTH}}_{{PAGE_HEIGHT}}_{{PAGE_COUNT}}_{{PAGE_UNKNOWN_VARIABLE}}.pdf";
 
-    Assert.That(() => sut.Replace(stringPlaceholders, 500, 500, 10), Throws.TypeOf<ArgumentException>()
+    Assert.That(() => Sut.Replace(stringPlaceholders, 500, 500, 10), Throws.TypeOf<ArgumentException>()
       .With.Message.Contains("PAGE_UNKNOWN_VARIABLE"));
   }
 
@@ -52,7 +47,7 @@ public class FilenameServiceTests
   {
     var stringPlaceholders = "test_{{PAGE_WIDTH}}_{{PAGE_HEIGHT}}}_{{PAGE_COUNT}}_{{PAGE_UNKNOWN_VARIABLE}}.pdf";
 
-    Assert.That(() => sut.Replace(stringPlaceholders, 500, 500, 10), Throws.TypeOf<ArgumentException>()
+    Assert.That(() => Sut.Replace(stringPlaceholders, 500, 500, 10), Throws.TypeOf<ArgumentException>()
       .With.Message.Contains("invalid bracket count"));
   }
 
@@ -61,6 +56,6 @@ public class FilenameServiceTests
   {
     var stringPlaceholders = "test_{{PAGE_WIDTH}}_{{PAGE_HEIGHT}}}}aaa{{_{{PAGE_COUNT}}_{{PAGE_UNKNOWN_VARIABLE}}.pdf";
 
-    Assert.That(() => sut.Replace(stringPlaceholders, 500, 500, 10), Throws.Exception);
+    Assert.That(() => Sut.Replace(stringPlaceholders, 500, 500, 10), Throws.Exception);
   }
 }

--- a/PdfGenerator.Test/Services/FooterContentService.cs
+++ b/PdfGenerator.Test/Services/FooterContentService.cs
@@ -2,23 +2,17 @@
 using PdfGenerator.Core.Services;
 
 namespace PdfGenerator.Test.Services;
-public class FooterContentServiceTests
+public class FooterContentServiceTests : TestBase<FooterContentService>
 {
   private const int DUMMY_WIDTH = 400;
   private const int DUMMY_HEIGHT = 400;
 
-  private FooterContentService? sut;
-
-  [SetUp]
-  public void Setup()
-  {
-    sut = new();
-  }
+  protected override FooterContentService DoSetup() => new();
 
   [Test]
   public void TestGetContentCreationStrategy_InputAreAllPageContentContentTypes_ProvidesStrategyForAllValues()
   {
     foreach (PdfFooterContent contentType in Enum.GetValues(typeof(PdfFooterContent)))
-      Assert.That(() => sut.GetContentCreationStrategy(contentType, DUMMY_WIDTH, DUMMY_HEIGHT), Throws.Nothing);
+      Assert.That(() => Sut.GetContentCreationStrategy(contentType, DUMMY_WIDTH, DUMMY_HEIGHT), Throws.Nothing);
   }
 }

--- a/PdfGenerator.Test/Services/FooterContentService.cs
+++ b/PdfGenerator.Test/Services/FooterContentService.cs
@@ -2,6 +2,7 @@
 using PdfGenerator.Core.Services;
 
 namespace PdfGenerator.Test.Services;
+
 public class FooterContentServiceTests : TestBase<FooterContentService>
 {
   private const int DUMMY_WIDTH = 400;

--- a/PdfGenerator.Test/Services/GeneratorService.cs
+++ b/PdfGenerator.Test/Services/GeneratorService.cs
@@ -1,24 +1,19 @@
 ﻿using Moq;
 using PdfGenerator.Core.Models;
 using PdfGenerator.Core.Services;
+using System.Diagnostics.CodeAnalysis;
 
 namespace PdfGenerator.Test.Services;
-public class GeneratorServiceTests
+public class GeneratorServiceTests : TestBase<GeneratorService>
 {
-  private GeneratorService? sut;
-
-  [SetUp]
-  public void Setup()
-  {
-    sut = new GeneratorService();
-  }
+  protected override GeneratorService DoSetup() => new();
 
   [Test]
   public void TestGenerate_InputIsStrategyStubs_CallsPageStubPageCountTimesAndFooterStubOneTime([Range(1, 30)] int pageCount)
   {
     var pageContentStrategyStub = new Mock<ContentCreationStrategy>();
     var footerContentStrategyStub = new Mock<ContentCreationStrategy>();
-    sut.Generate(400, 450, pageCount, pageContentStrategyStub.Object, footerContentStrategyStub.Object);
+    Sut.Generate(400, 450, pageCount, pageContentStrategyStub.Object, footerContentStrategyStub.Object);
     Assert.Multiple(() =>
     {
       Assert.That(pageContentStrategyStub.Invocations, Has.Count.EqualTo(pageCount));

--- a/PdfGenerator.Test/Services/GeneratorService.cs
+++ b/PdfGenerator.Test/Services/GeneratorService.cs
@@ -1,9 +1,9 @@
 ﻿using Moq;
 using PdfGenerator.Core.Models;
 using PdfGenerator.Core.Services;
-using System.Diagnostics.CodeAnalysis;
 
 namespace PdfGenerator.Test.Services;
+
 public class GeneratorServiceTests : TestBase<GeneratorService>
 {
   protected override GeneratorService DoSetup() => new();

--- a/PdfGenerator.Test/Services/MeasurementService.cs
+++ b/PdfGenerator.Test/Services/MeasurementService.cs
@@ -1,6 +1,5 @@
 ﻿using PdfGenerator.Core.Services;
 using QuestPDF.Helpers;
-using System.Diagnostics.CodeAnalysis;
 
 namespace PdfGenerator.Test.Services;
 

--- a/PdfGenerator.Test/Services/MeasurementService.cs
+++ b/PdfGenerator.Test/Services/MeasurementService.cs
@@ -1,20 +1,15 @@
 ﻿using PdfGenerator.Core.Services;
 using QuestPDF.Helpers;
+using System.Diagnostics.CodeAnalysis;
 
 namespace PdfGenerator.Test.Services;
 
-public class MeasurementServiceTest
+public class MeasurementServiceTest : TestBase<MeasurementService>
 {
   private const int VALID_PDF_MAX_SIZE = 14400;
   private const int VALID_PDF_MIN_SIZE = 300;
 
-  private MeasurementService? sut;
-
-  [SetUp]
-  public void Setup()
-  {
-    sut = new MeasurementService();
-  }
+  protected override MeasurementService DoSetup() => new();
 
   [Test]
   public void GetValidPageSize_InputIsValidPageSize_ReturnValidPagesizeAndNotUsingDefault()
@@ -24,8 +19,8 @@ public class MeasurementServiceTest
 
     foreach (var (pageSizeToTest, defaultSize) in validPageSizes.Zip(defaultPageSizesShifted))
     {
-      var testResult = sut.GetValidPageSize(pageSizeToTest, defaultSize);
-      var defaultResult = sut.GetValidPageSize(defaultSize);
+      var testResult = Sut.GetValidPageSize(pageSizeToTest, defaultSize);
+      var defaultResult = Sut.GetValidPageSize(defaultSize);
       Assert.Multiple(() =>
       {
         Assert.That(pageSizeToTest, Is.Not.EqualTo(defaultSize));
@@ -39,7 +34,7 @@ public class MeasurementServiceTest
   {
     var validPageSizes = typeof(PageSizes).GetProperties().Select(p => p.Name);
 
-    Assert.That(validPageSizes.All(sut.IsValidPageSize), Is.True);
+    Assert.That(validPageSizes.All(Sut.IsValidPageSize), Is.True);
   }
 
   [Test, Sequential]
@@ -49,7 +44,7 @@ public class MeasurementServiceTest
     Assert.Multiple(() =>
     {
       Assert.That(validPageSizes, Does.Not.Contain(pageSize));
-      Assert.That(sut.IsValidPageSize(pageSize), Is.False);
+      Assert.That(Sut.IsValidPageSize(pageSize), Is.False);
     });
   }
 
@@ -61,12 +56,12 @@ public class MeasurementServiceTest
   {
     var validPageSizes = typeof(PageSizes).GetProperties().Select(p => p.Name);
     var defaultPageSizesShifted = validPageSizes.Where((value, index) => index > 0).Concat(validPageSizes.Where((value, index) => index == 0));
-    var testResult = sut.GetValidPageSize(pageSize);
+    var testResult = Sut.GetValidPageSize(pageSize);
     Assert.Multiple(() =>
     {
-      Assert.That(sut.IsValidPageSize(pageSize), Is.False);
-      Assert.That(() => sut.GetValidPageSize(pageSize), Throws.Nothing);
-      Assert.That(testResult, Is.EqualTo(sut.GetValidPageSize("a4")));
+      Assert.That(Sut.IsValidPageSize(pageSize), Is.False);
+      Assert.That(() => Sut.GetValidPageSize(pageSize), Throws.Nothing);
+      Assert.That(testResult, Is.EqualTo(Sut.GetValidPageSize("a4")));
     });
   }
 
@@ -75,13 +70,13 @@ public class MeasurementServiceTest
     [Values("  ", "a100", "####", "AA1sdd")] string pageSize,
     [Values("  ", "a100", "####", "AA1sdd")] string defaultPageSize)
   {
-    var testResult = sut.GetValidPageSize("a4");
+    var testResult = Sut.GetValidPageSize("a4");
     Assert.Multiple(() =>
     {
-      Assert.That(sut.IsValidPageSize(pageSize), Is.False);
-      Assert.That(sut.IsValidPageSize(defaultPageSize), Is.False);
-      Assert.That(() => sut.GetValidPageSize(pageSize, defaultPageSize), Throws.Nothing);
-      Assert.That(testResult, Is.EqualTo(sut.GetValidPageSize("a4")));
+      Assert.That(Sut.IsValidPageSize(pageSize), Is.False);
+      Assert.That(Sut.IsValidPageSize(defaultPageSize), Is.False);
+      Assert.That(() => Sut.GetValidPageSize(pageSize, defaultPageSize), Throws.Nothing);
+      Assert.That(testResult, Is.EqualTo(Sut.GetValidPageSize("a4")));
     });
   }
 
@@ -92,9 +87,9 @@ public class MeasurementServiceTest
     [Range(VALID_PDF_MAX_SIZE + 1, VALID_PDF_MAX_SIZE + 11)] int upperInvalid)
     => Assert.Multiple(() =>
       {
-        Assert.That(sut.IsValidHeight(valid), Is.True);
-        Assert.That(sut.IsValidHeight(lowerInvalid), Is.False);
-        Assert.That(sut.IsValidHeight(upperInvalid), Is.False);
+        Assert.That(Sut.IsValidHeight(valid), Is.True);
+        Assert.That(Sut.IsValidHeight(lowerInvalid), Is.False);
+        Assert.That(Sut.IsValidHeight(upperInvalid), Is.False);
       });
 
   [Test, Combinatorial, Parallelizable]
@@ -104,9 +99,9 @@ public class MeasurementServiceTest
     [Range(VALID_PDF_MAX_SIZE + 1, VALID_PDF_MAX_SIZE + 11)] int upperInvalid)
     => Assert.Multiple(() =>
     {
-      Assert.That(sut.IsValidWidth(valid), Is.True);
-      Assert.That(sut.IsValidWidth(lowerInvalid), Is.False);
-      Assert.That(sut.IsValidWidth(upperInvalid), Is.False);
+      Assert.That(Sut.IsValidWidth(valid), Is.True);
+      Assert.That(Sut.IsValidWidth(lowerInvalid), Is.False);
+      Assert.That(Sut.IsValidWidth(upperInvalid), Is.False);
     });
 
   [Test, Sequential, Parallelizable]
@@ -115,8 +110,8 @@ public class MeasurementServiceTest
     [Values("  ", "fds", "786767a")] string invalidPageSize)
     => Assert.Multiple(() =>
     {
-      Assert.That(sut.IsValidPageSize(validPageSize), Is.True);
-      Assert.That(sut.IsValidPageSize(invalidPageSize), Is.False);
+      Assert.That(Sut.IsValidPageSize(validPageSize), Is.True);
+      Assert.That(Sut.IsValidPageSize(invalidPageSize), Is.False);
     });
 
   [Test, Combinatorial, Parallelizable]
@@ -125,10 +120,10 @@ public class MeasurementServiceTest
     [Range(VALID_PDF_MIN_SIZE - 11, VALID_PDF_MIN_SIZE - 1)] int invalid)
     => Assert.Multiple(() =>
     {
-      Assert.That(() => sut.GetPageSizeOrDefault(valid, valid), Throws.Nothing);
-      Assert.That(() => sut.GetPageSizeOrDefault(valid, invalid), Throws.Nothing);
-      Assert.That(() => sut.GetPageSizeOrDefault(invalid, valid), Throws.Nothing);
-      Assert.That(() => sut.GetPageSizeOrDefault(invalid, invalid), Throws.Nothing);
+      Assert.That(() => Sut.GetPageSizeOrDefault(valid, valid), Throws.Nothing);
+      Assert.That(() => Sut.GetPageSizeOrDefault(valid, invalid), Throws.Nothing);
+      Assert.That(() => Sut.GetPageSizeOrDefault(invalid, valid), Throws.Nothing);
+      Assert.That(() => Sut.GetPageSizeOrDefault(invalid, invalid), Throws.Nothing);
     });
 
 }

--- a/PdfGenerator.Test/Services/PageContentService.cs
+++ b/PdfGenerator.Test/Services/PageContentService.cs
@@ -2,23 +2,17 @@
 using PdfGenerator.Core.Services;
 
 namespace PdfGenerator.Test.Services;
-public class PageContentServiceTests
+public class PageContentServiceTests : TestBase<PageContentService>
 {
   private const int DUMMY_WIDTH = 400;
   private const int DUMMY_HEIGHT = 400;
 
-  private PageContentService? sut;
-
-  [SetUp]
-  public void Setup()
-  {
-    sut = new();
-  }
+  protected override PageContentService DoSetup() => new();
 
   [Test]
   public void TestGetContentCreationStrategy_InputAreAllPageContentContentTypes_ProvidesStrategyForAllValues()
   {
     foreach (PdfPageContent contentType in Enum.GetValues(typeof(PdfPageContent)))
-      Assert.That(() => sut.GetContentCreationStrategy(contentType, DUMMY_WIDTH, DUMMY_HEIGHT), Throws.Nothing);
+      Assert.That(() => Sut.GetContentCreationStrategy(contentType, DUMMY_WIDTH, DUMMY_HEIGHT), Throws.Nothing);
   }
 }

--- a/PdfGenerator.Test/Services/PageContentService.cs
+++ b/PdfGenerator.Test/Services/PageContentService.cs
@@ -2,6 +2,7 @@
 using PdfGenerator.Core.Services;
 
 namespace PdfGenerator.Test.Services;
+
 public class PageContentServiceTests : TestBase<PageContentService>
 {
   private const int DUMMY_WIDTH = 400;

--- a/PdfGenerator.Test/TestBase.cs
+++ b/PdfGenerator.Test/TestBase.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace PdfGenerator.Test;
+
+public abstract class TestBase<T>
+{
+  [NotNull] //Marking as not null here, because setup method is called before each test run.
+  protected T? Sut { get; private set; }
+
+  [SetUp]
+  public void Setup()
+  {
+    Sut = DoSetup();
+  }
+
+  [TearDown]
+  public void TearDown()
+  {
+    Sut = default;
+  }
+
+  protected abstract T DoSetup();
+}

--- a/PdfGenerator.Test/TestBase.cs
+++ b/PdfGenerator.Test/TestBase.cs
@@ -16,8 +16,10 @@ public abstract class TestBase<T>
   [TearDown]
   public void TearDown()
   {
+    DoTearDown();
     Sut = default;
   }
 
   protected abstract T DoSetup();
+  protected virtual void DoTearDown() { }
 }


### PR DESCRIPTION
Remove unnecessary null reference warnings in tests by providing a base class for all unit tests.
![image](https://user-images.githubusercontent.com/53836821/185811963-88604af6-b018-4cfd-9d52-1762479bd2e4.png)
